### PR TITLE
Add a user story for the Human Organ Atlas

### DIFF
--- a/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/0/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/0/zarr.json
@@ -1,0 +1,27 @@
+{
+  "node_type": "array",
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "shape": [6048, 6048, 4802],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+        "endian": "big"
+      }
+    }
+  ],
+  "data_type": "uint16",
+  "fill_value": 0,
+  "zarr_format": 3
+}

--- a/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/1/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/1/zarr.json
@@ -1,0 +1,27 @@
+{
+  "node_type": "array",
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "shape": [3024, 3024, 2401],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+        "endian": "big"
+      }
+    }
+  ],
+  "data_type": "uint16",
+  "fill_value": 0,
+  "zarr_format": 3
+}

--- a/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/zarr.json
@@ -1,0 +1,81 @@
+{
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "ome": {
+      "version": "0.6.dev1",
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "physical",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "0",
+                  "output": "physical",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [4.26, 4.26, 4.26]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [2.13, 2.13, 2.13]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "path": "1",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "1",
+                  "output": "physical",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [8.52, 8.52, 8.52]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [4.26, 4.26, 4.26]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/0/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/0/zarr.json
@@ -1,0 +1,27 @@
+{
+  "node_type": "array",
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "shape": [6048, 6048, 4802],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+        "endian": "big"
+      }
+    }
+  ],
+  "data_type": "uint16",
+  "fill_value": 0,
+  "zarr_format": 3
+}

--- a/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/1/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/1/zarr.json
@@ -1,0 +1,27 @@
+{
+  "node_type": "array",
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "shape": [3024, 3024, 2401],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+        "endian": "big"
+      }
+    }
+  ],
+  "data_type": "uint16",
+  "fill_value": 0,
+  "zarr_format": 3
+}

--- a/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/zarr.json
@@ -1,0 +1,81 @@
+{
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "ome": {
+      "version": "0.6.dev1",
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "physical",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "0",
+                  "output": "physical",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [4.26, 4.26, 4.26]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [2.13, 2.13, 2.13]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "path": "1",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "1",
+                  "output": "physical",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [8.52, 8.52, 8.52]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [4.26, 4.26, 4.26]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/0/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/0/zarr.json
@@ -1,0 +1,27 @@
+{
+  "node_type": "array",
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "shape": [6048, 6048, 4802],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+        "endian": "big"
+      }
+    }
+  ],
+  "data_type": "uint16",
+  "fill_value": 0,
+  "zarr_format": 3
+}

--- a/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/1/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/1/zarr.json
@@ -1,0 +1,27 @@
+{
+  "node_type": "array",
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "shape": [3024, 3024, 2401],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+        "endian": "big"
+      }
+    }
+  ],
+  "data_type": "uint16",
+  "fill_value": 0,
+  "zarr_format": 3
+}

--- a/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/zarr.json
@@ -1,0 +1,81 @@
+{
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "ome": {
+      "version": "0.6.dev1",
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "physical",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "0",
+                  "output": "physical",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [4.26, 4.26, 4.26]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [2.13, 2.13, 2.13]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "path": "1",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "1",
+                  "output": "physical",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [8.52, 8.52, 8.52]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [4.26, 4.26, 4.26]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/user_stories/human_organ_atlas.zarr/overview.ome.zarr/0/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/overview.ome.zarr/0/zarr.json
@@ -1,0 +1,27 @@
+{
+  "node_type": "array",
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "shape": [8308, 8308, 9564],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+        "endian": "big"
+      }
+    }
+  ],
+  "data_type": "uint16",
+  "fill_value": 0,
+  "zarr_format": 3
+}

--- a/user_stories/human_organ_atlas.zarr/overview.ome.zarr/1/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/overview.ome.zarr/1/zarr.json
@@ -1,0 +1,27 @@
+{
+  "node_type": "array",
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "shape": [4154, 4154, 4782],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+        "endian": "big"
+      }
+    }
+  ],
+  "data_type": "uint16",
+  "fill_value": 0,
+  "zarr_format": 3
+}

--- a/user_stories/human_organ_atlas.zarr/overview.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/overview.ome.zarr/zarr.json
@@ -30,6 +30,47 @@
                   "discrete": false
                 }
               ]
+            },
+            {
+              "name": "anatomical",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "coordinateTransformations": [
+            {
+              "type": "sequence",
+              "input": "physical",
+              "output": "anatomical",
+              "transformations": [
+                {
+                  "type": "rotation",
+                  "rotation": [
+                    [0, 0, 1],
+                    [0, 1, 0],
+                    [0, 0, 1]
+                  ]
+                },
+                { "type": "translation", "translation": [0, 0, 0] }
+              ]
             }
           ],
           "datasets": [

--- a/user_stories/human_organ_atlas.zarr/overview.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/overview.ome.zarr/zarr.json
@@ -1,0 +1,81 @@
+{
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "ome": {
+      "version": "0.6.dev1",
+      "multiscales": [
+        {
+          "name": "multiscales",
+          "coordinateSystems": [
+            {
+              "name": "physical",
+              "axes": [
+                {
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
+                },
+                {
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
+                }
+              ]
+            }
+          ],
+          "datasets": [
+            {
+              "path": "0",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "0",
+                  "output": "physical",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [24.132, 24.132, 24.132]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [12.066, 12.066, 12.066]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "path": "1",
+              "coordinateTransformations": [
+                {
+                  "type": "sequence",
+                  "input": "1",
+                  "output": "physical",
+                  "transformations": [
+                    {
+                      "type": "scale",
+                      "scale": [48.264, 48.264, 48.264]
+                    },
+                    {
+                      "type": "translation",
+                      "translation": [24.132, 24.132, 24.132]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/user_stories/human_organ_atlas.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/zarr.json
@@ -1,0 +1,75 @@
+{
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "ome": {
+      "version": "0.6dev2",
+      "coordinateTransformations": [
+        {
+          "type": "sequence",
+          "input": "VOI-03.ome.zarr",
+          "output": "overview.ome.zarr",
+          "name": "VOI-03 registration",
+          "transformations": [
+            { "type": "scale", "scale": [1, 1, 1] },
+            {
+              "type": "rotation",
+              "rotation": [
+                [0, 0, 1],
+                [0, 1, 0],
+                [0, 0, 1]
+              ]
+            },
+            {
+              "type": "translation",
+              "translation": [0, 0, 0]
+            }
+          ]
+        },
+        {
+          "type": "sequence",
+          "input": "VOI-02.ome.zarr",
+          "output": "overview.ome.zarr",
+          "name": "VOI-02 registration",
+          "transformations": [
+            { "type": "scale", "scale": [1, 1, 1] },
+            {
+              "type": "rotation",
+              "rotation": [
+                [0, 0, 1],
+                [0, 1, 0],
+                [0, 0, 1]
+              ]
+            },
+            {
+              "type": "translation",
+              "translation": [0, 0, 0]
+            }
+          ]
+        },
+        {
+          "type": "sequence",
+          "input": "VOI-01.ome.zarr",
+          "output": "overview.ome.zarr",
+          "name": "VOI-01 registration",
+          "transformations": [
+            { "type": "scale", "scale": [1, 1, 1] },
+            {
+              "type": "rotation",
+              "rotation": [
+                [0, 0, 1],
+                [0, 1, 0],
+                [0, 0, 1]
+              ]
+            },
+            {
+              "type": "translation",
+              "translation": [0, 0, 0]
+            }
+          ]
+        }
+      ],
+      "coordinateSystems": []
+    }
+  }
+}


### PR DESCRIPTION
This adds a user story example for the [Human Organ Atlas](https://human-organ-atlas.esrf.fr/) (my main project) that involves registration of several images (VOI images) to a main "overview" image. I don't think an example like this exists yet, so I think worthwhile to add. This is what the transform graph looks like:
<img width="2149" height="536" alt="human_organ_atlas" src="https://github.com/user-attachments/assets/9439701f-ece4-43f6-bcf5-dd64cf7db7be" />

