### PR TITLE
update version tag semantics

### DIFF
--- a/2d/axis_dependent/byDimension.zarr/zarr.json
+++ b/2d/axis_dependent/byDimension.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/2d/axis_dependent/mapAxis.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/basic/identity.zarr/zarr.json
+++ b/2d/basic/identity.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/basic/scale.zarr/zarr.json
+++ b/2d/basic/scale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/basic/scale_multiscale.zarr/zarr.json
+++ b/2d/basic/scale_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/basic/sequenceScaleTranslation.zarr/zarr.json
+++ b/2d/basic/sequenceScaleTranslation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
+++ b/2d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/basic_binary/scaleParams.zarr/zarr.json
+++ b/2d/basic_binary/scaleParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/basic_binary/translationParams.zarr/zarr.json
+++ b/2d/basic_binary/translationParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/nonlinear/invCoordinates.zarr/zarr.json
+++ b/2d/nonlinear/invCoordinates.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/nonlinear/invDisplacements.zarr/zarr.json
+++ b/2d/nonlinear/invDisplacements.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/simple/affine.zarr/zarr.json
+++ b/2d/simple/affine.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/simple/affineParams.zarr/zarr.json
+++ b/2d/simple/affineParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/simple/affine_multiscale.zarr/zarr.json
+++ b/2d/simple/affine_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/simple/multiscale.zarr/zarr.json
+++ b/2d/simple/multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/simple/rotation.zarr/zarr.json
+++ b/2d/simple/rotation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/2d/simple/rotationParams.zarr/zarr.json
+++ b/2d/simple/rotationParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/axis_dependent/byDimension.zarr/zarr.json
+++ b/3d/axis_dependent/byDimension.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/3d/axis_dependent/mapAxis.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/basic/identity.zarr/zarr.json
+++ b/3d/basic/identity.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/basic/scale.zarr/zarr.json
+++ b/3d/basic/scale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/basic/scale_multiscale.zarr/zarr.json
+++ b/3d/basic/scale_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/basic/sequenceScaleTranslation.zarr/zarr.json
+++ b/3d/basic/sequenceScaleTranslation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
+++ b/3d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/basic_binary/scaleParams.zarr/zarr.json
+++ b/3d/basic_binary/scaleParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/basic_binary/translationParams.zarr/zarr.json
+++ b/3d/basic_binary/translationParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/nonlinear/invCoordinates.zarr/zarr.json
+++ b/3d/nonlinear/invCoordinates.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/nonlinear/invDisplacements.zarr/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/simple/affine.zarr/zarr.json
+++ b/3d/simple/affine.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/simple/affineParams.zarr/zarr.json
+++ b/3d/simple/affineParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/simple/affine_multiscale.zarr/zarr.json
+++ b/3d/simple/affine_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/simple/rotation.zarr/zarr.json
+++ b/3d/simple/rotation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/3d/simple/rotationParams.zarr/zarr.json
+++ b/3d/simple/rotationParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/SCAPE.zarr/stack/zarr.json
+++ b/user_stories/SCAPE.zarr/stack/zarr.json
@@ -1,7 +1,7 @@
 {
 	"attributes": {
 		"ome": {
-			"version": "0.6dev2",
+			"version": "0.6.dev2",
 			"multiscales": [
 				{
 					"coordinateSystems": [

--- a/user_stories/SCAPE.zarr/zarr.json
+++ b/user_stories/SCAPE.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "coordinateTransformations": [
         {
           "type": "translation",

--- a/user_stories/human_organ_atlas.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "coordinateTransformations": [
         {
           "type": "sequence",

--- a/user_stories/image_registration_3d.zarr/FCWB/zarr.json
+++ b/user_stories/image_registration_3d.zarr/FCWB/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/image_registration_3d.zarr/JRC2018F/zarr.json
+++ b/user_stories/image_registration_3d.zarr/JRC2018F/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/image_registration_3d.zarr/zarr.json
+++ b/user_stories/image_registration_3d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "coordinateTransformations": [
         {
           "type": "bijection",

--- a/user_stories/lens_correction.zarr/image/zarr.json
+++ b/user_stories/lens_correction.zarr/image/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "multiscales": [
         {
           "name": "multiscales",

--- a/user_stories/lens_correction.zarr/zarr.json
+++ b/user_stories/lens_correction.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "coordinateTransformations": [
         {
           "type": "byDimension",

--- a/user_stories/stitched_tiles_2d.zarr/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "coordinateTransformations": [
         {
           "type": "translation",

--- a/user_stories/stitched_tiles_3d.zarr/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6dev2",
+      "version": "0.6.dev2",
       "coordinateTransformations": [
         {
           "type": "translation",


### PR DESCRIPTION
Updating the semantics of the versions. Turns out that `0.6dev2` isn't *quite* a valid version tag for some version control tools. Many of such tools (i.e., setuptools_scm) reserve the `.dev` field for their own version management of local builds, but there are other issues, too. In the future we may change to a different naming.

cc @dstansby