### PR TITLE
add scene field to examples

### DIFF
--- a/user_stories/SCAPE.zarr/zarr.json
+++ b/user_stories/SCAPE.zarr/zarr.json
@@ -4,37 +4,39 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev2",
-      "coordinateTransformations": [
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "stack", "name": "unskewed"},
-          "translation": [
-            5882.2,
-            44249.4
-          ],
-          "name": "stack to world"
-        }
-      ],
-      "coordinateSystems": [
-        {
-          "name": "world",
-          "axes": [
-            {
-              "type": "space",
-              "name": "x",
-              "unit": "micrometer",
-              "discrete": false
-            },
-            {
-              "type": "space",
-              "name": "y",
-              "unit": "micrometer",
-              "discrete": false
-            }
-          ]
-        }
-      ]
+      "scene": {
+        "coordinateTransformations": [
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "stack", "name": "unskewed"},
+            "translation": [
+              5882.2,
+              44249.4
+            ],
+            "name": "stack to world"
+          }
+        ],
+        "coordinateSystems": [
+          {
+            "name": "world",
+            "axes": [
+              {
+                "type": "space",
+                "name": "x",
+                "unit": "micrometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "y",
+                "unit": "micrometer",
+                "discrete": false
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/user_stories/human_organ_atlas.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/zarr.json
@@ -4,72 +4,74 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev2",
-      "coordinateTransformations": [
-        {
-          "type": "sequence",
-          "input": {"path": "VOI-03.ome.zarr", "name": "physical"},
-          "output": {"path": "overview.ome.zarr", "name": "physical"},
-          "name": "VOI-03 registration",
-          "transformations": [
-            { "type": "scale", "scale": [1, 1, 1] },
-            {
-              "type": "rotation",
-              "rotation": [
-                [1, 0, 0],
-                [0, 1, 0],
-                [0, 0, 1]
-              ]
-            },
-            {
-              "type": "translation",
-              "translation": [0, 0, 0]
-            }
-          ]
-        },
-        {
-          "type": "sequence",
-          "input": {"path": "VOI-02.ome.zarr", "name": "physical"},
-          "output": {"path": "overview.ome.zarr", "name": "physical"},
-          "name": "VOI-02 registration",
-          "transformations": [
-            { "type": "scale", "scale": [1, 1, 1] },
-            {
-              "type": "rotation",
-              "rotation": [
-                [1, 0, 0],
-                [0, 1, 0],
-                [0, 0, 1]
-              ]
-            },
-            {
-              "type": "translation",
-              "translation": [0, 0, 0]
-            }
-          ]
-        },
-        {
-          "type": "sequence",
-          "input": {"path": "VOI-01.ome.zarr", "name": "physical"},
-          "output": {"path": "overview.ome.zarr", "name": "physical"},
-          "name": "VOI-01 registration",
-          "transformations": [
-            { "type": "scale", "scale": [1, 1, 1] },
-            {
-              "type": "rotation",
-              "rotation": [
-                [1, 0, 0],
-                [0, 1, 0],
-                [0, 0, 1]
-              ]
-            },
-            {
-              "type": "translation",
-              "translation": [0, 0, 0]
-            }
-          ]
-        }
-      ],
-      "coordinateSystems": []
+      "scene":{
+        "coordinateTransformations": [
+          {
+            "type": "sequence",
+            "input": {"path": "VOI-03.ome.zarr", "name": "physical"},
+            "output": {"path": "overview.ome.zarr", "name": "physical"},
+            "name": "VOI-03 registration",
+            "transformations": [
+              { "type": "scale", "scale": [1, 1, 1] },
+              {
+                "type": "rotation",
+                "rotation": [
+                  [1, 0, 0],
+                  [0, 1, 0],
+                  [0, 0, 1]
+                ]
+              },
+              {
+                "type": "translation",
+                "translation": [0, 0, 0]
+              }
+            ]
+          },
+          {
+            "type": "sequence",
+            "input": {"path": "VOI-02.ome.zarr", "name": "physical"},
+            "output": {"path": "overview.ome.zarr", "name": "physical"},
+            "name": "VOI-02 registration",
+            "transformations": [
+              { "type": "scale", "scale": [1, 1, 1] },
+              {
+                "type": "rotation",
+                "rotation": [
+                  [1, 0, 0],
+                  [0, 1, 0],
+                  [0, 0, 1]
+                ]
+              },
+              {
+                "type": "translation",
+                "translation": [0, 0, 0]
+              }
+            ]
+          },
+          {
+            "type": "sequence",
+            "input": {"path": "VOI-01.ome.zarr", "name": "physical"},
+            "output": {"path": "overview.ome.zarr", "name": "physical"},
+            "name": "VOI-01 registration",
+            "transformations": [
+              { "type": "scale", "scale": [1, 1, 1] },
+              {
+                "type": "rotation",
+                "rotation": [
+                  [1, 0, 0],
+                  [0, 1, 0],
+                  [0, 0, 1]
+                ]
+              },
+              {
+                "type": "translation",
+                "translation": [0, 0, 0]
+              }
+            ]
+          }
+        ],
+        "coordinateSystems": []
+      }
     }
   }
 }

--- a/user_stories/image_registration_3d.zarr/zarr.json
+++ b/user_stories/image_registration_3d.zarr/zarr.json
@@ -4,82 +4,84 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev2",
-      "coordinateTransformations": [
-        {
-          "type": "bijection",
-          "input": {"path": "JRC2018F", "name": "JRC2018F"},
-          "output": "FCWB",
-          "forward": {
-            "type": "sequence",
-            "name": "JRC2018F to FCWB",
-            "transformations": [
-              {
-                "type": "displacements",
-                "path": "coordinateTransformations/dfield",
-                "interpolation": "linear"
-              },
-              {
-                "type": "affine",
-                "affine": [
-                  [
-                    0.549687,
-                    -0.0138092,
-                    0.000127526,
-                    2.9986
-                  ],
-                  [
-                    0.0893289,
-                    1.04339,
-                    -0.000121014,
-                    -6.39702
-                  ],
-                  [
-                    0.00779285,
-                    0.00299018,
-                    0.907875,
-                    -3.77146
+      "scene": {
+        "coordinateTransformations": [
+          {
+            "type": "bijection",
+            "input": {"path": "JRC2018F", "name": "JRC2018F"},
+            "output": "FCWB",
+            "forward": {
+              "type": "sequence",
+              "name": "JRC2018F to FCWB",
+              "transformations": [
+                {
+                  "type": "displacements",
+                  "path": "coordinateTransformations/dfield",
+                  "interpolation": "linear"
+                },
+                {
+                  "type": "affine",
+                  "affine": [
+                    [
+                      0.549687,
+                      -0.0138092,
+                      0.000127526,
+                      2.9986
+                    ],
+                    [
+                      0.0893289,
+                      1.04339,
+                      -0.000121014,
+                      -6.39702
+                    ],
+                    [
+                      0.00779285,
+                      0.00299018,
+                      0.907875,
+                      -3.77146
+                    ]
                   ]
-                ]
-              }
-            ]
-          },
-          "inverse": {
-            "type": "sequence",
-            "name": "FCWB to JRC2018F",
-            "transformations": [
-              {
-                "type": "affine",
-                "affine": [
-                  [
-                    1.8153162032371448,
-                    0.024026315573955494,
-                    -0.00025178851007148946,
-                    -5.290659956068192
-                  ],
-                  [
-                    -0.1554184181171034,
-                    0.9563570184920926,
-                    0.00014930742384645888,
-                    6.584435749976974
-                  ],
-                  [
-                    -0.015070089856986017,
-                    -0.003356093187801388,
-                    1.1014748899286995,
-                    4.177888664571422
+                }
+              ]
+            },
+            "inverse": {
+              "type": "sequence",
+              "name": "FCWB to JRC2018F",
+              "transformations": [
+                {
+                  "type": "affine",
+                  "affine": [
+                    [
+                      1.8153162032371448,
+                      0.024026315573955494,
+                      -0.00025178851007148946,
+                      -5.290659956068192
+                    ],
+                    [
+                      -0.1554184181171034,
+                      0.9563570184920926,
+                      0.00014930742384645888,
+                      6.584435749976974
+                    ],
+                    [
+                      -0.015070089856986017,
+                      -0.003356093187801388,
+                      1.1014748899286995,
+                      4.177888664571422
+                    ]
                   ]
-                ]
-              },
-              {
-                "type": "displacements",
-                "path": "coordinateTransformations/invdfield",
-                "interpolation": "linear",
-                "name": ""
-              }
-            ]
+                },
+                {
+                  "type": "displacements",
+                  "path": "coordinateTransformations/invdfield",
+                  "interpolation": "linear",
+                  "name": ""
+                }
+              ]
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   }
 }

--- a/user_stories/lens_correction.zarr/zarr.json
+++ b/user_stories/lens_correction.zarr/zarr.json
@@ -4,64 +4,66 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev2",
-      "coordinateTransformations": [
-        {
-          "type": "byDimension",
-          "input": {"path": "image", "name": "raw"},
-          "output": "corrected",
-          "transformations": [
-            {
-              "type": "displacements",
-              "name": "lens correction",
-              "path": "coordinateTransformations/lensCorrection",
-              "interpolation": "linear",
-              "input_axes": [
-                "y",
-                "x"
-              ],
-              "output_axes": [
-                "y",
-                "x"
-              ]
-            },
-            {
-              "type": "identity",
-              "input_axes": [
-                "z"
-              ],
-              "output_axes": [
-                "z"
-              ]
-            }
-          ],
-          "name": "lens correction 3d"
-        }
-      ],
-      "coordinateSystems": [
-        {
-          "name": "corrected",
-          "axes": [
-            {
-              "type": "space",
-              "name": "z",
-              "unit": "nanometer",
-              "discrete": false
-            },
-            {
-              "type": "space",
-              "name": "y",
-              "unit": "nanometer",
-              "discrete": false
-            },
-            {
-              "type": "space",
-              "name": "x",
-              "unit": "nanometer",
-              "discrete": false
-            }
-          ]
-        }
-      ]
+      "scene": {
+        "coordinateTransformations": [
+          {
+            "type": "byDimension",
+            "input": {"path": "image", "name": "raw"},
+            "output": "corrected",
+            "transformations": [
+              {
+                "type": "displacements",
+                "name": "lens correction",
+                "path": "coordinateTransformations/lensCorrection",
+                "interpolation": "linear",
+                "input_axes": [
+                  "y",
+                  "x"
+                ],
+                "output_axes": [
+                  "y",
+                  "x"
+                ]
+              },
+              {
+                "type": "identity",
+                "input_axes": [
+                  "z"
+                ],
+                "output_axes": [
+                  "z"
+                ]
+              }
+            ],
+            "name": "lens correction 3d"
+          }
+        ],
+        "coordinateSystems": [
+          {
+            "name": "corrected",
+            "axes": [
+              {
+                "type": "space",
+                "name": "z",
+                "unit": "nanometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "y",
+                "unit": "nanometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "x",
+                "unit": "nanometer",
+                "discrete": false
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/user_stories/stitched_tiles_2d.zarr/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/zarr.json
@@ -4,67 +4,69 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev2",
-      "coordinateTransformations": [
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_0", "name": "physical"},
-          "translation": [
-            0,
-            0
-          ],
-          "name": "tile_0_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_1", "name": "physical"},
-          "translation": [
-            0,
-            348
-          ],
-          "name": "tile_1_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_2", "name": "physical"},
-          "translation": [
-            276,
-            0
-          ],
-          "name": "tile_2_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_3", "name": "physical"},
-          "translation": [
-            276,
-            348
-          ],
-          "name": "tile_3_mm to world"
-        }
-      ],
-      "coordinateSystems": [
-        {
-          "name": "world",
-          "axes": [
-            {
-              "type": "space",
-              "name": "x",
-              "unit": "micrometer",
-              "discrete": false
-            },
-            {
-              "type": "space",
-              "name": "y",
-              "unit": "micrometer",
-              "discrete": false
-            }
-          ]
-        }
-      ]
+      "scene": {
+        "coordinateTransformations": [
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_0", "name": "physical"},
+            "translation": [
+              0,
+              0
+            ],
+            "name": "tile_0_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_1", "name": "physical"},
+            "translation": [
+              0,
+              348
+            ],
+            "name": "tile_1_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_2", "name": "physical"},
+            "translation": [
+              276,
+              0
+            ],
+            "name": "tile_2_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_3", "name": "physical"},
+            "translation": [
+              276,
+              348
+            ],
+            "name": "tile_3_mm to world"
+          }
+        ],
+        "coordinateSystems": [
+          {
+            "name": "world",
+            "axes": [
+              {
+                "type": "space",
+                "name": "x",
+                "unit": "micrometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "y",
+                "unit": "micrometer",
+                "discrete": false
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/user_stories/stitched_tiles_3d.zarr/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/zarr.json
@@ -4,121 +4,123 @@
   "attributes": {
     "ome": {
       "version": "0.6.dev2",
-      "coordinateTransformations": [
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_0", "name": "physical"},
-          "translation": [
-            0,
-            0,
-            0
-          ],
-          "name": "tile_0_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_1", "name": "physical"},
-          "translation": [
-            0,
-            0,
-            82
-          ],
-          "name": "tile_1_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_2", "name": "physical"},
-          "translation": [
-            0,
-            102,
-            0
-          ],
-          "name": "tile_2_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_3", "name": "physical"},
-          "translation": [
-            0,
-            102,
-            82
-          ],
-          "name": "tile_3_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_4", "name": "physical"},
-          "translation": [
-            3,
-            0,
-            0
-          ],
-          "name": "tile_4_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_5", "name": "physical"},
-          "translation": [
-            3,
-            0,
-            82
-          ],
-          "name": "tile_5_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_6", "name": "physical"},
-          "translation": [
-            3,
-            102,
-            0
-          ],
-          "name": "tile_6_mm to world"
-        },
-        {
-          "type": "translation",
-          "output": "world",
-          "input": {"path": "tile_7", "name": "physical"},
-          "translation": [
-            3,
-            102,
-            82
-          ],
-          "name": "tile_7_mm to world"
-        }
-      ],
-      "coordinateSystems": [
-        {
-          "name": "world",
-          "axes": [
-            {
-              "type": "space",
-              "name": "x",
-              "unit": "micrometer",
-              "discrete": false
-            },
-            {
-              "type": "space",
-              "name": "y",
-              "unit": "micrometer",
-              "discrete": false
-            },
-            {
-              "type": "space",
-              "name": "z",
-              "unit": "micrometer",
-              "discrete": false
-            }
-          ]
-        }
-      ]
+      "scene": {
+        "coordinateTransformations": [
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_0", "name": "physical"},
+            "translation": [
+              0,
+              0,
+              0
+            ],
+            "name": "tile_0_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_1", "name": "physical"},
+            "translation": [
+              0,
+              0,
+              82
+            ],
+            "name": "tile_1_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_2", "name": "physical"},
+            "translation": [
+              0,
+              102,
+              0
+            ],
+            "name": "tile_2_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_3", "name": "physical"},
+            "translation": [
+              0,
+              102,
+              82
+            ],
+            "name": "tile_3_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_4", "name": "physical"},
+            "translation": [
+              3,
+              0,
+              0
+            ],
+            "name": "tile_4_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_5", "name": "physical"},
+            "translation": [
+              3,
+              0,
+              82
+            ],
+            "name": "tile_5_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_6", "name": "physical"},
+            "translation": [
+              3,
+              102,
+              0
+            ],
+            "name": "tile_6_mm to world"
+          },
+          {
+            "type": "translation",
+            "output": "world",
+            "input": {"path": "tile_7", "name": "physical"},
+            "translation": [
+              3,
+              102,
+              82
+            ],
+            "name": "tile_7_mm to world"
+          }
+        ],
+        "coordinateSystems": [
+          {
+            "name": "world",
+            "axes": [
+              {
+                "type": "space",
+                "name": "x",
+                "unit": "micrometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "y",
+                "unit": "micrometer",
+                "discrete": false
+              },
+              {
+                "type": "space",
+                "name": "z",
+                "unit": "micrometer",
+                "discrete": false
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
@dstansby talk about not seeing the forest for the trees. Since we are introducing a new name for the top-level collection, we'd probably also need to introduce the corresponding field in the examples. Just pinging you here because you'll probably need to introduce this over at ome-zarr-models-py, too.