### PR TITLE
Fix invalid multiscales axes types

### DIFF
--- a/2d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/2d/axis_dependent/mapAxis.zarr/zarr.json
@@ -29,12 +29,12 @@
               "name": "array_coordinates",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_0",
                   "discrete": true
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_1",
                   "discrete": true
                 }

--- a/2d/nonlinear/coordinates.zarr/zarr.json
+++ b/2d/nonlinear/coordinates.zarr/zarr.json
@@ -29,12 +29,12 @@
               "name": "scaled",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "y",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "x",
                   "discrete": false
                 }

--- a/2d/nonlinear/displacements.zarr/zarr.json
+++ b/2d/nonlinear/displacements.zarr/zarr.json
@@ -29,12 +29,12 @@
               "name": "displaced",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "y",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "x",
                   "discrete": false
                 }

--- a/3d/nonlinear/coordinates.zarr/zarr.json
+++ b/3d/nonlinear/coordinates.zarr/zarr.json
@@ -35,17 +35,17 @@
               "name": "physical",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "z",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "y",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "x",
                   "discrete": false
                 }

--- a/3d/nonlinear/invDisplacements.zarr/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/zarr.json
@@ -35,17 +35,17 @@
               "name": "physical",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "z",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "y",
                   "discrete": false
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "x",
                   "discrete": false
                 }


### PR DESCRIPTION
This fixes various multiscale axes to comply with

> The axes MUST contain 2 or 3 entries of type:space

(https://ngff-spec.readthedocs.io/en/latest/#multiscales-metadata)