### PR TITLE
Fix 3D mapAxis example

### DIFF
--- a/3d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/3d/axis_dependent/mapAxis.zarr/zarr.json
@@ -30,26 +30,6 @@
                   "discrete": false
                 }
               ]
-            },
-            {
-              "name": "array",
-              "axes": [
-                {
-                  "type": "array",
-                  "name": "dim_0",
-                  "discrete": true
-                },
-                {
-                  "type": "array",
-                  "name": "dim_1",
-                  "discrete": true
-                },
-                {
-                  "type": "array",
-                  "name": "dim_2",
-                  "discrete": true
-                }
-              ]
             }
           ],
           "datasets": [
@@ -67,15 +47,51 @@
           ],
           "coordinateTransformations": [
             {
-              "type": "mapAxis",
+              "type": "scale",
               "output": "physical",
-              "input": "array",
+              "input": "0",
+              "name": "transform-name",
+              "scale": [1, 1, 1]
+            }
+          ]
+        }
+      ],
+      "coordinateSystems": [
+        {
+          "name": "transposed",
+          "axes": [
+            {
+              "type": "space",
+              "name": "z",
+              "unit": "micrometer",
+              "discrete": false
+            },
+            {
+              "type": "space",
+              "name": "y",
+              "unit": "micrometer",
+              "discrete": false
+            },
+            {
+              "type": "space",
+              "name": "x",
+              "unit": "micrometer",
+              "discrete": false
+            }
+          ]
+        }
+      ],
+      "coordinateTransformations": [
+            {
+              "type": "mapAxis",
+              "output": "transposed",
+              "input": "physical",
               "name": "transform-name",
               "mapAxis": [2, 1, 0]
             }
           ]
         }
       ]
-    }
+  }
   }
 }

--- a/3d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/3d/axis_dependent/mapAxis.zarr/zarr.json
@@ -42,7 +42,6 @@
                   "input": "0"
                 }
               ]
-
             }
           ],
           "coordinateTransformations": [
@@ -82,16 +81,14 @@
         }
       ],
       "coordinateTransformations": [
-            {
-              "type": "mapAxis",
-              "output": "transposed",
-              "input": "physical",
-              "name": "transform-name",
-              "mapAxis": [2, 1, 0]
-            }
-          ]
+        {
+          "type": "mapAxis",
+          "output": "transposed",
+          "input": "physical",
+          "name": "transform-name",
+          "mapAxis": [2, 1, 0]
         }
       ]
-  }
+    }
   }
 }


### PR DESCRIPTION
Inside a multiscales

> The axes MUST contain 2 or 3 entries of type:space

([ngff-spec.readthedocs.io/en/latest#multiscales-metadata](https://ngff-spec.readthedocs.io/en/latest/#multiscales-metadata))

This fixes one of the mapAxis examples to comply with this requirement, by moving the mapAxis transform and associated coordinate system out of the multiscales metadata.

ping @jo-mueller - I think this is the correct way to write this metadata? There are others to fix like this, so let me know if this looks good and then I can fix the rest. 