### PR TITLE
feat: update to 0.6.dev4

### DIFF
--- a/2d/axis_dependent/byDimension.zarr/zarr.json
+++ b/2d/axis_dependent/byDimension.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": "array_coordinates",
-                  "input": "s0",
+                  "output": {"name": "array_coordinates"},
+                  "input": {"path": "s0"},
                   "name": "transform-name"
                 }
               ]
@@ -57,8 +57,8 @@
           "coordinateTransformations": [
             {
               "type": "byDimension",
-              "output": "physical",
-              "input": "array_coordinates",
+              "output": {"name": "physical"},
+              "input": {"name": "array_coordinates"},
               "transformations": [
                 {
                   "transformation": {

--- a/2d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/2d/axis_dependent/mapAxis.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "array_coordinates",
-                  "input": "array",
+                  "output": {"name": "array_coordinates"},
+                  "input": {"path": "array"},
                   "name": "default-scale",
                   "scale": [1, 1]
                 }
@@ -58,8 +58,8 @@
           "coordinateTransformations": [
             {
               "type": "mapAxis",
-              "output": "physical",
-              "input": "array_coordinates",
+              "output": {"name": "physical"},
+              "input": {"name": "array_coordinates"},
               "name": "transform-name",
               "mapAxis": [1, 0]
             }

--- a/2d/basic/identity.zarr/zarr.json
+++ b/2d/basic/identity.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "transform-name"
                 }
               ]

--- a/2d/basic/scale.zarr/zarr.json
+++ b/2d/basic/scale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "transform-name",
                   "scale": [
                     3.0,

--- a/2d/basic/scale_multiscale.zarr/zarr.json
+++ b/2d/basic/scale_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "transform-name",
                   "scale": [
                     6.0,
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "transform-name",
                   "scale": [
                     12.0,
@@ -62,8 +62,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "transform-name",
                   "scale": [
                     24.0,

--- a/2d/basic/sequenceScaleTranslation.zarr/zarr.json
+++ b/2d/basic/sequenceScaleTranslation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/2d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
+++ b/2d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -60,8 +60,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -88,8 +88,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/2d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
+++ b/2d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
@@ -70,8 +70,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "0",
-          "input": "0",
+          "output": {"name": "0"},
+          "input": {"path": "0"},
           "scale": [
             1,
             1,

--- a/2d/nonlinear/coordinates.zarr/zarr.json
+++ b/2d/nonlinear/coordinates.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "scaled",
-                  "input": "0",
+                  "output": {"name": "scaled"},
+                  "input": {"path": "0"},
                   "scale": [1, 1],
                   "name": "tform-name"
                 }
@@ -58,8 +58,8 @@
           "coordinateTransformations": [
             {
               "type": "coordinates",
-              "output": "scaled",
-              "input": "physical",
+              "output": {"name": "scaled"},
+              "input": {"name": "physical"},
               "path": "coordinatesField",
               "interpolation": "linear",
               "name": "inverse-cfield"

--- a/2d/nonlinear/displacements.zarr/displacementField/zarr.json
+++ b/2d/nonlinear/displacements.zarr/displacementField/zarr.json
@@ -70,8 +70,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "0",
-          "input": "0",
+          "output": {"name": "0"},
+          "input": {"path": "0"},
           "scale": [
             1,
             1,

--- a/2d/nonlinear/displacements.zarr/zarr.json
+++ b/2d/nonlinear/displacements.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -47,8 +47,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "scale": [1, 1],
                   "name": "scale-transform"
                 }
@@ -58,8 +58,8 @@
           "coordinateTransformations": [
             {
               "type": "displacements",
-              "output": "displaced",
-              "input": "physical",
+              "output": {"name": "displaced"},
+              "input": {"name": "physical"},
               "path": "displacementField",
               "interpolation": "linear",
               "name": "inverse-dfield"

--- a/2d/simple/affine.zarr/zarr.json
+++ b/2d/simple/affine.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "array2physical",
                   "scale": [1, 1]
                 }
@@ -60,8 +60,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "output": "sheared",
-              "input": "physical",
+              "output": {"name": "sheared"},
+              "input": {"name": "physical"},
               "name": "shear-transformation",
               "affine": [
                 [

--- a/2d/simple/affineParams.zarr/zarr.json
+++ b/2d/simple/affineParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "array-to-physical",
                   "scale": [0.5, 0.5]
                 }
@@ -60,8 +60,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "input": "physical",
-              "output": "sheared",
+              "input": {"name": "physical"},
+              "output": {"name": "sheared"},
               "path": "affineParams",
               "name": "shearing-transform"
             }

--- a/2d/simple/affine_multiscale.zarr/zarr.json
+++ b/2d/simple/affine_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "scale0_to_physical",
                   "transformations": [
                     {
@@ -70,8 +70,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "scale1_to_physical",
                   "transformations": [
                     {
@@ -91,8 +91,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "scale2_to_physical",
                   "transformations": [
                     {
@@ -112,8 +112,8 @@
             {
               "type": "affine",
               "name": "physical-to-sheared",
-              "input": "physical",
-              "output": "sheared",
+              "input": {"name": "physical"},
+              "output": {"name": "sheared"},
               "affine": [
                 [
                   3,

--- a/2d/simple/multiscale.zarr/zarr.json
+++ b/2d/simple/multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "scale0_to_physical",
                   "transformations": [
                     {
@@ -53,8 +53,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "scale1_to_physical",
                   "transformations": [
                     {
@@ -74,8 +74,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "scale2_to_physical",
                   "transformations": [
                     {

--- a/2d/simple/rotation.zarr/zarr.json
+++ b/2d/simple/rotation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "scale": [1, 1],
                   "name": "array to physical"
                 }
@@ -60,8 +60,8 @@
           "coordinateTransformations":[
             {
               "name": "rotation",
-              "input": "physical",
-              "output": "rotated",
+              "input": {"name": "physical"},
+              "output": {"name": "rotated"},
               "type": "rotation",
               "rotation": [
                 [0, 1],

--- a/2d/simple/rotationParams.zarr/zarr.json
+++ b/2d/simple/rotationParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -49,8 +49,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "scale": [1.4, 1.4]
                 }
               ]
@@ -59,9 +59,9 @@
           "coordinateTransformations": [
             {
               "type": "rotation",
-              "output": "rotated",
+              "output": {"name": "rotated"},
               "path": "rotationParams",
-              "input": "physical",
+              "input": {"name": "physical"},
               "name": "image-rotation"
             }
           ]

--- a/3d/axis_dependent/byDimension.zarr/zarr.json
+++ b/3d/axis_dependent/byDimension.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "input": "0",
-                  "output": "array"
+                  "input": {"path": "0"},
+                  "output": {"name": "array"}
                 }
               ]
 
@@ -68,8 +68,8 @@
           "coordinateTransformations": [
             {
               "type": "byDimension",
-              "output": "physical",
-              "input": "array",
+              "output": {"name": "physical"},
+              "input": {"name": "array"},
               "transformations": [
                 {
                   "type": "scale",

--- a/3d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/3d/axis_dependent/mapAxis.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": "array",
-                  "input": "0"
+                  "output": {"name": "array"},
+                  "input": {"path": "0"}
                 }
               ]
 
@@ -68,8 +68,8 @@
           "coordinateTransformations": [
             {
               "type": "mapAxis",
-              "output": "physical",
-              "input": "array",
+              "output": {"name": "physical"},
+              "input": {"name": "array"},
               "name": "transform-name",
               "mapAxis": [2, 1, 0]
             }

--- a/3d/basic/identity.zarr/zarr.json
+++ b/3d/basic/identity.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "transform-name"
                 }
               ]

--- a/3d/basic/scale.zarr/zarr.json
+++ b/3d/basic/scale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -35,8 +35,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "transform-name",
                   "scale": [
                     4,

--- a/3d/basic/scale_multiscale.zarr/zarr.json
+++ b/3d/basic/scale_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "transform-name",
                   "scale": [
                     4,
@@ -54,8 +54,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "transform-name",
                   "scale": [
                     8,
@@ -70,8 +70,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "transform-name",
                   "scale": [
                     16,

--- a/3d/basic/sequenceScaleTranslation.zarr/zarr.json
+++ b/3d/basic/sequenceScaleTranslation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/3d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
+++ b/3d/basic/sequenceScaleTranslation_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -68,8 +68,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -98,8 +98,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/3d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
+++ b/3d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
@@ -72,8 +72,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "0",
-          "input": "0",
+          "output": {"name": "0"},
+          "input": {"name": "0"},
           "scale": [
             1,
             1,

--- a/3d/nonlinear/coordinates.zarr/zarr.json
+++ b/3d/nonlinear/coordinates.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "scale": [0.5, 0.5, 0.5],
                   "name": "array-to-physical"
                 }
@@ -69,8 +69,8 @@
           "coordinateTransformations": [
             {
               "type": "coordinates",
-              "output": "displaced",
-              "input": "physical",
+              "output": {"name": "displaced"},
+              "input": {"name": "physical"},
               "path": "coordinatesField",
               "interpolation": "linear",
               "name": "inverse-cfield"

--- a/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
@@ -78,8 +78,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "0",
-          "input": "0",
+          "output": {"name": "0"},
+          "input": {"name": "0"},
           "scale": [
             1,
             1,

--- a/3d/nonlinear/invDisplacements.zarr/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "scale": [0.5, 0.5, 0.5],
                   "name": "scale-transform"
                 }
@@ -70,8 +70,8 @@
           "coordinateTransformations": [
             {
               "type": "displacements",
-              "output": "physical",
-              "input": "displaced",
+              "output": {"name": "physical"},
+              "input": {"name": "displaced"},
               "path": "displacementField",
               "interpolation": "linear",
               "name": "inverse-dfield"

--- a/3d/simple/affine.zarr/zarr.json
+++ b/3d/simple/affine.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -61,8 +61,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "array-to-physical",
                   "scale": [
                     1,
@@ -76,8 +76,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "output": "sheared",
-              "input": "physical",
+              "output": {"name": "sheared"},
+              "input": {"name": "physical"},
               "name": "physical-to-sheared",
               "affine": [
                 [

--- a/3d/simple/affineParams.zarr/zarr.json
+++ b/3d/simple/affineParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -62,8 +62,8 @@
                 {
                   "type": "scale",
                   "scale": [1.0, 0.5, 0.5],
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "image-to-physical"
                 }
               ]
@@ -72,8 +72,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "input": "physical",
-              "output": "sheared",
+              "input": {"name": "physical"},
+              "output": {"name": "sheared"},
               "path": "affineParams",
               "name": "physical-to-sheared"
             }

--- a/3d/simple/affine_multiscale.zarr/zarr.json
+++ b/3d/simple/affine_multiscale.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -61,8 +61,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s0"},
                   "name": "s0 to physical",
                   "transformations": [
                     {
@@ -90,8 +90,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s1",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s1"},
                   "name": "s1 to physical",
                   "transformations": [
                     {
@@ -119,8 +119,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "physical",
-                  "input": "s2",
+                  "output": {"name": "physical"},
+                  "input": {"path": "s2"},
                   "name": "s2 to physical",
                   "transformations": [
                     {
@@ -147,8 +147,8 @@
           "coordinateTransformations": [
             {
               "type": "affine",
-              "output": "sheared",
-              "input": "physical",
+              "output": {"name": "sheared"},
+              "input": {"name": "physical"},
               "name": "physical-to-sheared",
               "affine": [
                 [

--- a/3d/simple/rotation.zarr/zarr.json
+++ b/3d/simple/rotation.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -61,8 +61,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "scale": [1, 1, 1],
                   "name": "array-to-physical"
                 }
@@ -72,8 +72,8 @@
           "coordinateTransformations": [
             {
               "type": "rotation",
-              "output": "rotated",
-              "input": "physical",
+              "output": {"name": "rotated"},
+              "input": {"name": "physical"},
               "rotation": [
                 [
                   0,

--- a/3d/simple/rotationParams.zarr/zarr.json
+++ b/3d/simple/rotationParams.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -62,8 +62,8 @@
                 {
                   "type": "scale",
                   "scale": [1, 1, 1],
-                  "output": "physical",
-                  "input": "array",
+                  "output": {"name": "physical"},
+                  "input": {"path": "array"},
                   "name": "array-to-physical"
                 }
               ]
@@ -72,9 +72,9 @@
           "coordinateTransformations": [
             {
               "type": "rotation",
-              "output": "rotated",
+              "output": {"name": "rotated"},
               "path": "rotationParams",
-              "input": "physical",
+              "input": {"name": "physical"},
               "name": "physical-to-rotated"
             }
           ]

--- a/user_stories/SCAPE.zarr/stack/zarr.json
+++ b/user_stories/SCAPE.zarr/stack/zarr.json
@@ -1,7 +1,7 @@
 {
 	"attributes": {
 		"ome": {
-			"version": "0.6.dev3",
+			"version": "0.6.dev4",
 			"multiscales": [
 				{
 					"coordinateSystems": [
@@ -56,8 +56,8 @@
 								{
                                     "name": "scale0 to physical",
                                     "type": "sequence",
-                                    "input": "scale0",
-                                    "output": "physical",
+                                    "input": {"path": "scale0"},
+                                    "output": {"name": "physical"},
                                     "transformations": [
                                         {
                                             "type": "scale",
@@ -85,8 +85,8 @@
 								{
 									"type": "sequence",
 									"name": "scale1 to physical",
-									"input": "scale1",
-									"output": "physical",
+									"input": {"path": "scale1"},
+									"output": {"name": "physical"},
 									"transformations": [
 										{
 											"scale": [
@@ -112,8 +112,8 @@
 					"coordinateTransformations":[
 						{
 							"name": "deskewing",
-							"input": "physical",
-							"output": "unskewed",
+							"input": {"name": "physical"},
+							"output": {"name": "unskewed"},
 							"type": "affine",
 							"affine": [
 								[1.0, 0.0, 0.0, 0.0],

--- a/user_stories/SCAPE.zarr/zarr.json
+++ b/user_stories/SCAPE.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {

--- a/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-01.ome.zarr/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "0",
-                  "output": "physical",
+                  "input": {"path": "0"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "1",
-                  "output": "physical",
+                  "input": {"path": "1"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-02.ome.zarr/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "0",
-                  "output": "physical",
+                  "input": {"path": "0"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "1",
-                  "output": "physical",
+                  "input": {"path": "1"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/VOI-03.ome.zarr/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "0",
-                  "output": "physical",
+                  "input": {"path": "0"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -58,8 +58,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "1",
-                  "output": "physical",
+                  "input": {"path": "1"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/human_organ_atlas.zarr/overview.ome.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/overview.ome.zarr/zarr.json
@@ -58,8 +58,8 @@
           "coordinateTransformations": [
             {
               "type": "sequence",
-              "input": "physical",
-              "output": "anatomical",
+              "input": {"name": "physical"},
+              "output": {"name": "anatomical"},
               "transformations": [
                 {
                   "type": "rotation",
@@ -79,8 +79,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "0",
-                  "output": "physical",
+                  "input": {"path": "0"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",
@@ -99,8 +99,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "1",
-                  "output": "physical",
+                  "input": {"path": "1"},
+                  "output": {"name": "physical"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/human_organ_atlas.zarr/zarr.json
+++ b/user_stories/human_organ_atlas.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene":{
         "coordinateTransformations": [
           {

--- a/user_stories/image_registration_3d.zarr/FCWB/zarr.json
+++ b/user_stories/image_registration_3d.zarr/FCWB/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "FCWB",
-                  "input": "s0",
+                  "output": {"name": "FCWB"},
+                  "input": {"path": "s0"},
                   "scale": [
                     1.2,
                     1.2,
@@ -53,8 +53,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "output": "FCWB",
-                  "input": "s1",
+                  "output": {"name": "FCWB"},
+                  "input": {"path": "s1"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/image_registration_3d.zarr/JRC2018F/zarr.json
+++ b/user_stories/image_registration_3d.zarr/JRC2018F/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "JRC2018F",
-                  "input": "s0",
+                  "output": {"name": "JRC2018F"},
+                  "input": {"path": "s0"},
                   "scale": [
                     1.24296,
                     1.24296,
@@ -53,8 +53,8 @@
               "coordinateTransformations": [
                 {
                   "type": "sequence",
-                  "input": "s1",
-                  "output": "JRC2018F",
+                  "input": {"path": "s1"},
+                  "output": {"name": "JRC2018F"},
                   "transformations": [
                     {
                       "type": "scale",

--- a/user_stories/image_registration_3d.zarr/zarr.json
+++ b/user_stories/image_registration_3d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {

--- a/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
+++ b/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
@@ -67,8 +67,8 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "raw2d",
-          "input": ".",
+          "output": {"name": "raw2d"},
+          "input": {"path": "."},
           "name": "displacement field sample spacing",
           "scale": [
             5,

--- a/user_stories/lens_correction.zarr/image/zarr.json
+++ b/user_stories/lens_correction.zarr/image/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "multiscales": [
         {
           "name": "multiscales",
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "raw",
-                  "input": "0",
+                  "output": {"name": "raw"},
+                  "input": {"path": "0"},
                   "scale": [
                     1,
                     1,

--- a/user_stories/lens_correction.zarr/zarr.json
+++ b/user_stories/lens_correction.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {

--- a/user_stories/stitched_tiles_2d.zarr/tile_0/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_0/zarr.json
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_0 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_2d.zarr/tile_1/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_1/zarr.json
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_1 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_2d.zarr/tile_2/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_2/zarr.json
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_2 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_2d.zarr/tile_3/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/tile_3/zarr.json
@@ -32,8 +32,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_3 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_2d.zarr/zarr.json
+++ b/user_stories/stitched_tiles_2d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {

--- a/user_stories/stitched_tiles_3d.zarr/tile_0/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_0/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_0 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_1/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_1/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_1 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_2/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_2/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_2 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_3/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_3/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_3 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_4/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_4/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_4 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_5/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_5/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_5 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_6/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_6/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_6 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/tile_7/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/tile_7/zarr.json
@@ -38,8 +38,8 @@
               "coordinateTransformations": [
                 {
                   "type": "scale",
-                  "output": "physical",
-                  "input": "0",
+                  "output": {"name": "physical"},
+                  "input": {"path": "0"},
                   "name": "tile_7 to physical",
                   "scale": [
                     1,

--- a/user_stories/stitched_tiles_3d.zarr/zarr.json
+++ b/user_stories/stitched_tiles_3d.zarr/zarr.json
@@ -3,7 +3,7 @@
   "node_type": "group",
   "attributes": {
     "ome": {
-      "version": "0.6.dev3",
+      "version": "0.6.dev4",
       "scene": {
         "coordinateTransformations": [
           {


### PR DESCRIPTION
Re https://github.com/ome/ngff-spec/pull/117
 
This pull request updates several Zarr metadata JSON files to align with the OME-NGFF specification version `0.6.dev4`. The main changes involve updating the version number and standardizing the structure of `input` and `output` fields in coordinate transformation objects. Rather than using plain strings, these fields now use objects with explicit `name` or `path` keys, improving clarity and consistency in the metadata.

The most important changes are:

**OME-NGFF Version Update:**
* Updated the `ome.version` field from `0.6.dev3` to `0.6.dev4` in all affected `.zarr/zarr.json` files to reflect the latest specification. [[1]](diffhunk://#diff-3fa1e4a1ecb3d9de1809f7e05ff89d7415bcba9db66bf85bb91b5eace7a02c4fL6-R6) [[2]](diffhunk://#diff-b793b866f839137507017ebc88a961d69a7665eeb7a5b3e5a284156660420808L6-R6) [[3]](diffhunk://#diff-2eb581773e6e24898358d642b7bc1a082a0177af875dd568e48b34de546d44a7L6-R6) [[4]](diffhunk://#diff-1c48b5c4b7b63e7c10f64054aa1904a6a311232ecd994968d17186499e03af4fL6-R6) [[5]](diffhunk://#diff-5e7bf428acc39808ab319b8fba691764783fbb4fee55d5cf9d4836fe79856cb3L6-R6) [[6]](diffhunk://#diff-14b4a9be36a2ef698724f42af96651e92f6889f81a39629d5df723196486f101L6-R6) [[7]](diffhunk://#diff-a3f75f0d1871da1c3ef31f8568f423f2c916689be0f6d8bfb951ac99b362d4eeL6-R6) [[8]](diffhunk://#diff-7b38997b287098281fd5aa22312facb0a58ac1a32c2b42fe9b2249d74beaf3e3L6-R6) [[9]](diffhunk://#diff-fd8a182ad4cd444c63f61f15d676112a71dc36cb748b40873a46ecbbc6c1f7a5L6-R6) [[10]](diffhunk://#diff-1fa5b5b8deae76089dc411aa265b1d3f8053ca991f6663ce88804442226f7e89L6-R6) [[11]](diffhunk://#diff-503e8e3653e198081797894d8922df10246162ef794172cc5eda15328240323aL6-R6) [[12]](diffhunk://#diff-daaa747c7ff4a6a11bd0713aa9969ceee84b919aef3fcf4e904ae210b02033d9L6-R6)

**Coordinate Transformation Structure Standardization:**
* Changed `input` and `output` fields in all `coordinateTransformations` from plain strings to objects with either a `name` (for conceptual axes) or `path` (for array references), e.g., `"output": {"name": "physical"}` or `"input": {"path": "array"}`. This applies to all transformation types, including `scale`, `identity`, `byDimension`, `mapAxis`, `sequence`, `affine`, `coordinates`, and `displacements`. [[1]](diffhunk://#diff-3fa1e4a1ecb3d9de1809f7e05ff89d7415bcba9db66bf85bb91b5eace7a02c4fL50-R51) [[2]](diffhunk://#diff-3fa1e4a1ecb3d9de1809f7e05ff89d7415bcba9db66bf85bb91b5eace7a02c4fL60-R61) [[3]](diffhunk://#diff-b793b866f839137507017ebc88a961d69a7665eeb7a5b3e5a284156660420808L50-R51) [[4]](diffhunk://#diff-b793b866f839137507017ebc88a961d69a7665eeb7a5b3e5a284156660420808L61-R62) [[5]](diffhunk://#diff-2eb581773e6e24898358d642b7bc1a082a0177af875dd568e48b34de546d44a7L35-R36) [[6]](diffhunk://#diff-1c48b5c4b7b63e7c10f64054aa1904a6a311232ecd994968d17186499e03af4fL35-R36) [[7]](diffhunk://#diff-5e7bf428acc39808ab319b8fba691764783fbb4fee55d5cf9d4836fe79856cb3L35-R36) [[8]](diffhunk://#diff-5e7bf428acc39808ab319b8fba691764783fbb4fee55d5cf9d4836fe79856cb3L50-R51) [[9]](diffhunk://#diff-5e7bf428acc39808ab319b8fba691764783fbb4fee55d5cf9d4836fe79856cb3L65-R66) [[10]](diffhunk://#diff-14b4a9be36a2ef698724f42af96651e92f6889f81a39629d5df723196486f101L35-R36) [[11]](diffhunk://#diff-a3f75f0d1871da1c3ef31f8568f423f2c916689be0f6d8bfb951ac99b362d4eeL35-R36) [[12]](diffhunk://#diff-a3f75f0d1871da1c3ef31f8568f423f2c916689be0f6d8bfb951ac99b362d4eeL63-R64) [[13]](diffhunk://#diff-a3f75f0d1871da1c3ef31f8568f423f2c916689be0f6d8bfb951ac99b362d4eeL91-R92) [[14]](diffhunk://#diff-b16b9f1b7cb0ebc931bd75c52299e0dd7e712be8f6215c2e3a80756783b33339L73-R74) [[15]](diffhunk://#diff-7b38997b287098281fd5aa22312facb0a58ac1a32c2b42fe9b2249d74beaf3e3L50-R51) [[16]](diffhunk://#diff-7b38997b287098281fd5aa22312facb0a58ac1a32c2b42fe9b2249d74beaf3e3L61-R62) [[17]](diffhunk://#diff-fd8a182ad4cd444c63f61f15d676112a71dc36cb748b40873a46ecbbc6c1f7a5L50-R51) [[18]](diffhunk://#diff-fd8a182ad4cd444c63f61f15d676112a71dc36cb748b40873a46ecbbc6c1f7a5L61-R62) [[19]](diffhunk://#diff-1fa5b5b8deae76089dc411aa265b1d3f8053ca991f6663ce88804442226f7e89L52-R53) [[20]](diffhunk://#diff-1fa5b5b8deae76089dc411aa265b1d3f8053ca991f6663ce88804442226f7e89L63-R64) [[21]](diffhunk://#diff-503e8e3653e198081797894d8922df10246162ef794172cc5eda15328240323aL52-R53) [[22]](diffhunk://#diff-503e8e3653e198081797894d8922df10246162ef794172cc5eda15328240323aL63-R64) [[23]](diffhunk://#diff-daaa747c7ff4a6a11bd0713aa9969ceee84b919aef3fcf4e904ae210b02033d9L52-R53) [[24]](diffhunk://#diff-4fca87aa5d4b02a6ce3d9afbba55120b1e24957ca55c37e9dcafe91752bf3947L73-R74)

These changes ensure the metadata is consistent with the updated OME-NGFF specification and improve interoperability and clarity for downstream tools and users.