### PR TITLE
fix: remove input fields in displacements

### DIFF
--- a/2d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
+++ b/2d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
@@ -71,7 +71,6 @@
         {
           "type": "scale",
           "output": {"name": "0"},
-          "input": {"path": "0"},
           "scale": [
             1,
             1,

--- a/2d/nonlinear/displacements.zarr/displacementField/zarr.json
+++ b/2d/nonlinear/displacements.zarr/displacementField/zarr.json
@@ -71,7 +71,6 @@
         {
           "type": "scale",
           "output": {"name": "0"},
-          "input": {"path": "0"},
           "scale": [
             1,
             1,

--- a/3d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
+++ b/3d/nonlinear/coordinates.zarr/coordinatesField/zarr.json
@@ -73,7 +73,6 @@
         {
           "type": "scale",
           "output": {"name": "0"},
-          "input": {"name": "0"},
           "scale": [
             1,
             1,

--- a/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
+++ b/3d/nonlinear/invDisplacements.zarr/displacementField/zarr.json
@@ -79,7 +79,6 @@
         {
           "type": "scale",
           "output": {"name": "0"},
-          "input": {"name": "0"},
           "scale": [
             1,
             1,

--- a/user_stories/image_registration_3d.zarr/coordinateTransformations/dfield/zarr.json
+++ b/user_stories/image_registration_3d.zarr/coordinateTransformations/dfield/zarr.json
@@ -81,8 +81,7 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "JRC2018F",
-          "input": "dfield",
+          "output": {"name": "JRC2018F"},
           "name": "",
           "scale": [
             1.76,

--- a/user_stories/image_registration_3d.zarr/coordinateTransformations/invdfield/zarr.json
+++ b/user_stories/image_registration_3d.zarr/coordinateTransformations/invdfield/zarr.json
@@ -75,8 +75,7 @@
       "coordinateTransformations": [
         {
           "type": "scale",
-          "output": "FCWB",
-          "input": "invdfield",
+          "output": {"name": "FCWB"},
           "name": "",
           "scale": [
             1.76,

--- a/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
+++ b/user_stories/lens_correction.zarr/coordinateTransformations/lensCorrection/zarr.json
@@ -68,7 +68,6 @@
         {
           "type": "scale",
           "output": {"name": "raw2d"},
-          "input": {"path": "."},
           "name": "displacement field sample spacing",
           "scale": [
             5,


### PR DESCRIPTION
According to the spec, the input field in the array description of displacements/coordinates can be omitted:

> Note: The input field is omitted, as it is implicitly the pixel coordinate system of the array (defined by the first N axes of the array’s coordinateSystem).