### PR TITLE
Fix examples

### DIFF
--- a/2d/axis_dependent/byDimension.zarr/zarr.json
+++ b/2d/axis_dependent/byDimension.zarr/zarr.json
@@ -26,17 +26,19 @@
               ]
             },
             {
-              "name": "array_coordinates",
+              "name": "y-scaled",
               "axes": [
                 {
-                  "type": "array",
-                  "name": "dim_0",
-                  "discrete": true
+                  "type": "space",
+                  "name": "y",
+                  "unit": "nanometer",
+                  "discrete": false
                 },
                 {
-                  "type": "array",
-                  "name": "dim_1",
-                  "discrete": true
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
                 }
               ]
             }
@@ -47,7 +49,7 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": {"name": "array_coordinates"},
+                  "output": {"name": "physical"},
                   "input": {"path": "s0"},
                   "name": "transform-name"
                 }
@@ -57,24 +59,16 @@
           "coordinateTransformations": [
             {
               "type": "byDimension",
-              "output": {"name": "physical"},
-              "input": {"name": "array_coordinates"},
+              "output": {"name": "y-scaled"},
+              "input": {"name": "physical"},
               "transformations": [
                 {
                   "transformation": {
                     "type": "scale",
-                    "scale": [2]
+                    "scale": [1000]
                   },
                   "output_axes": [1],
                   "input_axes": [1]
-                },
-                {
-                  "transformation": {
-                    "type": "translation",
-                    "translation": [-10]
-                  },
-                  "output_axes": [0],
-                  "input_axes": [0]
                 }
               ],
               "name": "transform-name"

--- a/3d/axis_dependent/byDimension.zarr/zarr.json
+++ b/3d/axis_dependent/byDimension.zarr/zarr.json
@@ -32,22 +32,25 @@
               ]
             },
             {
-              "name": "array",
+              "name": "y-scaled",
               "axes": [
                 {
                   "type": "space",
-                  "name": "dim_0",
-                  "discrete": true
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
                 },
                 {
                   "type": "space",
-                  "name": "dim_1",
-                  "discrete": true
+                  "name": "y",
+                  "unit": "nanometer",
+                  "discrete": false
                 },
                 {
                   "type": "space",
-                  "name": "dim_2",
-                  "discrete": true
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
                 }
               ]
             }
@@ -58,34 +61,26 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
+                  "output": {"name": "physical"},
                   "input": {"path": "0"},
-                  "output": {"name": "array"}
+                  "name": "transform-name"
                 }
               ]
-
             }
           ],
           "coordinateTransformations": [
             {
               "type": "byDimension",
-              "output": {"name": "physical"},
-              "input": {"name": "array"},
+              "output": {"name": "y-scaled"},
+              "input": {"name": "physical"},
               "transformations": [
                 {
                   "transformation": {
                     "type": "scale",
-                    "scale": [3, 2]
+                    "scale": [1000]
                   },
-                  "output_axes": [2, 1],
-                  "input_axes": [0, 1]
-                },
-                {
-                  "transformation": {
-                    "type": "translation",
-                    "translation": [10]
-                  },
-                  "output_axes": [0],
-                  "input_axes": [2]
+                  "output_axes": [1],
+                  "input_axes": [1]
                 }
               ],
               "name": "transform-name"

--- a/3d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/3d/axis_dependent/mapAxis.zarr/zarr.json
@@ -32,22 +32,25 @@
               ]
             },
             {
-              "name": "array",
+              "name": "permuted",
               "axes": [
                 {
-                  "type": "array",
-                  "name": "dim_0",
-                  "discrete": true
+                  "type": "space",
+                  "name": "z",
+                  "unit": "micrometer",
+                  "discrete": false
                 },
                 {
-                  "type": "array",
-                  "name": "dim_1",
-                  "discrete": true
+                  "type": "space",
+                  "name": "y",
+                  "unit": "micrometer",
+                  "discrete": false
                 },
                 {
-                  "type": "array",
-                  "name": "dim_2",
-                  "discrete": true
+                  "type": "space",
+                  "name": "x",
+                  "unit": "micrometer",
+                  "discrete": false
                 }
               ]
             }
@@ -58,7 +61,7 @@
               "coordinateTransformations": [
                 {
                   "type": "identity",
-                  "output": {"name": "array"},
+                  "output": {"name": "physical"},
                   "input": {"path": "0"}
                 }
               ]
@@ -68,8 +71,8 @@
           "coordinateTransformations": [
             {
               "type": "mapAxis",
-              "output": {"name": "physical"},
-              "input": {"name": "array"},
+              "output": {"name": "permuted"},
+              "input": {"name": "physical"},
               "name": "transform-name",
               "mapAxis": [2, 1, 0]
             }


### PR DESCRIPTION
Some example fixes to ensure all coordinate systems in multiscales have at least two spatial axes