### PR TITLE
feat: Use 'space' for axis type in zarr.json

### DIFF
--- a/2d/axis_dependent/byDimension.zarr/zarr.json
+++ b/2d/axis_dependent/byDimension.zarr/zarr.json
@@ -29,12 +29,12 @@
               "name": "array_coordinates",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_0",
                   "discrete": true
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_1",
                   "discrete": true
                 }

--- a/3d/axis_dependent/mapAxis.zarr/zarr.json
+++ b/3d/axis_dependent/mapAxis.zarr/zarr.json
@@ -35,17 +35,17 @@
               "name": "array",
               "axes": [
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_0",
                   "discrete": true
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_1",
                   "discrete": true
                 },
                 {
-                  "type": "array",
+                  "type": "space",
                   "name": "dim_2",
                   "discrete": true
                 }


### PR DESCRIPTION
Replace axis "type" values from "array" to "space" for dimension entries in 2d/axis_dependent/byDimension.zarr/zarr.json and 3d/axis_dependent/mapAxis.zarr/zarr.json to align axis metadata with the expected Zarr schema/semantics.

cc @dstansby 